### PR TITLE
fix(resource): normalize ntfy topic timestamps

### DIFF
--- a/src/mcp-server/resources/definitions/ntfy-topic.resource.ts
+++ b/src/mcp-server/resources/definitions/ntfy-topic.resource.ts
@@ -8,7 +8,7 @@
 
 import { resource, z } from '@cyanheads/mcp-ts-core';
 import { forbidden } from '@cyanheads/mcp-ts-core/errors';
-
+import { shapeNtfyMessage } from '@/mcp-server/utils/ntfy-message-shape.js';
 import { getCode, getMessage, isAuthCode } from '@/services/ntfy/error-classifier.js';
 import { getNtfyService } from '@/services/ntfy/ntfy-service.js';
 import type { NtfyMessage } from '@/services/ntfy/types.js';
@@ -66,7 +66,7 @@ export const ntfyTopicResource = resource('ntfy://{topic}', {
       url: `${service.baseUrl}/${params.topic}`,
       baseUrl: service.baseUrl,
       since: SNAPSHOT_SINCE,
-      messages: slice,
+      messages: slice.map(shapeNtfyMessage),
       count: slice.length,
       truncated,
     };

--- a/src/mcp-server/tools/definitions/ntfy-fetch-messages.tool.ts
+++ b/src/mcp-server/tools/definitions/ntfy-fetch-messages.tool.ts
@@ -13,6 +13,7 @@ import { tool, z } from '@cyanheads/mcp-ts-core';
 import { JsonRpcErrorCode, validationError } from '@cyanheads/mcp-ts-core/errors';
 
 import { getServerConfig } from '@/config/server-config.js';
+import { MESSAGE_TRUNCATE_AT, shapeNtfyMessage } from '@/mcp-server/utils/ntfy-message-shape.js';
 import {
   getCode,
   getMessage,
@@ -24,7 +25,6 @@ import { getNtfyService } from '@/services/ntfy/ntfy-service.js';
 import type { NtfyMessage, Priority } from '@/services/ntfy/types.js';
 
 const TOPIC_LIST_REGEX = /^[a-zA-Z0-9_-]+(?:,[a-zA-Z0-9_-]+)*$/;
-const MESSAGE_TRUNCATE_AT = 500;
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 
@@ -224,7 +224,6 @@ const OutputSchema = z.object({
 
 type Input = z.infer<typeof InputSchema>;
 type Output = z.infer<typeof OutputSchema>;
-type OutputMessage = Output['messages'][number];
 type FilterEcho = z.infer<typeof FilterEchoSchema>;
 
 function priorityLabel(p?: Priority): string {
@@ -240,38 +239,6 @@ function priorityLabel(p?: Priority): string {
     default:
       return 'default';
   }
-}
-
-function truncateMessage(body: string | undefined): {
-  message?: string;
-  messageTruncated?: number;
-} {
-  if (body === undefined) return {};
-  if (body.length <= MESSAGE_TRUNCATE_AT) return { message: body };
-  return {
-    message: body.slice(0, MESSAGE_TRUNCATE_AT),
-    messageTruncated: body.length - MESSAGE_TRUNCATE_AT,
-  };
-}
-
-function shapeMessage(raw: NtfyMessage): OutputMessage {
-  const truncation = truncateMessage(raw.message);
-  return {
-    id: raw.id,
-    time: new Date(raw.time * 1000).toISOString(),
-    event: raw.event as OutputMessage['event'],
-    topic: raw.topic,
-    expires: raw.expires !== undefined ? new Date(raw.expires * 1000).toISOString() : undefined,
-    sequence_id: raw.sequence_id,
-    title: raw.title,
-    message: truncation.message,
-    messageTruncated: truncation.messageTruncated,
-    priority: raw.priority,
-    tags: raw.tags,
-    click: raw.click,
-    actions: raw.actions as OutputMessage['actions'],
-    attachment: raw.attachment,
-  };
 }
 
 function filterSummary(f: FilterEcho | undefined): string {
@@ -435,7 +402,7 @@ export const ntfyFetchMessages = tool('ntfy_fetch_messages', {
       );
     }
 
-    return { messages: slice.map(shapeMessage) };
+    return { messages: slice.map(shapeNtfyMessage) };
   },
 
   format(result) {

--- a/src/mcp-server/utils/ntfy-message-shape.ts
+++ b/src/mcp-server/utils/ntfy-message-shape.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Shared ntfy message normalizer for tools/resources that expose
+ * cached upstream messages to MCP clients.
+ * @module mcp-server/utils/ntfy-message-shape
+ */
+
+import type {
+  MessageEvent,
+  NtfyAction,
+  NtfyAttachment,
+  NtfyMessage,
+  Priority,
+} from '@/services/ntfy/types.js';
+
+export const MESSAGE_TRUNCATE_AT = 500;
+
+export interface ShapedNtfyMessage {
+  actions?: NtfyAction[] | undefined;
+  attachment?: NtfyAttachment | undefined;
+  click?: string | undefined;
+  event: MessageEvent;
+  expires?: string | undefined;
+  id: string;
+  message?: string | undefined;
+  messageTruncated?: number | undefined;
+  priority?: Priority | undefined;
+  sequence_id?: string | undefined;
+  tags?: string[] | undefined;
+  time: string;
+  title?: string | undefined;
+  topic: string;
+}
+
+function truncateMessage(body: string | undefined): {
+  message?: string;
+  messageTruncated?: number;
+} {
+  if (body === undefined) return {};
+  if (body.length <= MESSAGE_TRUNCATE_AT) return { message: body };
+  return {
+    message: body.slice(0, MESSAGE_TRUNCATE_AT),
+    messageTruncated: body.length - MESSAGE_TRUNCATE_AT,
+  };
+}
+
+export function shapeNtfyMessage(raw: NtfyMessage): ShapedNtfyMessage {
+  const truncation = truncateMessage(raw.message);
+  return {
+    id: raw.id,
+    time: new Date(raw.time * 1000).toISOString(),
+    event: raw.event as MessageEvent,
+    topic: raw.topic,
+    expires: raw.expires !== undefined ? new Date(raw.expires * 1000).toISOString() : undefined,
+    sequence_id: raw.sequence_id,
+    title: raw.title,
+    message: truncation.message,
+    messageTruncated: truncation.messageTruncated,
+    priority: raw.priority,
+    tags: raw.tags,
+    click: raw.click,
+    actions: raw.actions,
+    attachment: raw.attachment,
+  };
+}

--- a/tests/resources/ntfy-topic.resource.test.ts
+++ b/tests/resources/ntfy-topic.resource.test.ts
@@ -51,18 +51,31 @@ describe('ntfyTopicResource handler', () => {
     const svc = freshService();
     vi.spyOn(svc, 'fetch').mockResolvedValue([
       { id: 'a', time: 1, event: 'open', topic: 'alerts' },
-      { id: 'b', time: 2, event: 'message', topic: 'alerts', message: 'hi' },
+      {
+        id: 'b',
+        time: 1_700_000_000,
+        expires: 1_700_003_600,
+        event: 'message',
+        topic: 'alerts',
+        message: 'hi',
+      },
     ]);
     const ctx = createMockContext({ uri: new URL('ntfy://alerts') });
     const result = (await ntfyTopicResource.handler({ topic: 'alerts' }, ctx)) as {
       topic: string;
       url: string;
-      messages: unknown[];
+      messages: Array<{ expires?: string; id: string; message?: string; time: string }>;
       count: number;
     };
     expect(result.topic).toBe('alerts');
     expect(result.url).toBe('https://ntfy.test/alerts');
     expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({
+      id: 'b',
+      message: 'hi',
+      time: '2023-11-14T22:13:20.000Z',
+      expires: '2023-11-14T23:13:20.000Z',
+    });
     expect(result.count).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- Normalize `ntfy://{topic}` resource messages with the same ISO timestamp/body truncation shaping used by `ntfy_fetch_messages`.
- Extract the shared message shaping helper so tool/resource responses stay consistent.
- Add resource coverage for ISO `time`/`expires` values.

## Test Plan
- [x] `bun test tests/resources/ntfy-topic.resource.test.ts tests/tools/ntfy-fetch-messages.tool.test.ts`
- [x] `bun run build`
- [ ] `bun run devcheck` (passes Biome, TypeScript, packaging, audit; fails only the existing dependency-outdated check for `@cyanheads/mcp-ts-core` 0.9.16→0.9.21 and `vitest` 4.1.7→4.1.8)

Closes #8
