### PR TITLE
fix(ntfy): preserve multi-topic fetch path

### DIFF
--- a/src/services/ntfy/ntfy-service.ts
+++ b/src/services/ntfy/ntfy-service.ts
@@ -53,6 +53,10 @@ function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
+function encodeTopicList(topic: string): string {
+  return topic.split(',').map(encodeURIComponent).join(',');
+}
+
 function buildAuthHeader(entry: NtfyServerEntry): string | undefined {
   if (entry.authToken) return `Bearer ${entry.authToken}`;
   if (entry.authUsername && entry.authPassword) {
@@ -202,7 +206,7 @@ export class NtfyService {
     if (params.title) search.set('title', params.title);
     if (params.message) search.set('message', params.message);
 
-    const url = `${base}/${encodeURIComponent(params.topic)}/json?${search.toString()}`;
+    const url = `${base}/${encodeTopicList(params.topic)}/json?${search.toString()}`;
 
     return await this.run(
       async (signal) => {

--- a/tests/services/ntfy/ntfy-service.test.ts
+++ b/tests/services/ntfy/ntfy-service.test.ts
@@ -343,11 +343,11 @@ describe('NtfyService.fetch request shape', () => {
     expect(url.searchParams.get('message')).toBe('disk full');
   });
 
-  it('URL-encodes the topic segment for comma-separated lists', async () => {
+  it('preserves comma-separated topics as separate ntfy subscriptions', async () => {
     const svc = new NtfyService(makeConfig([{ baseUrl: 'https://ntfy.test' }]));
     const { calls } = captureFetch(ndjsonResponder(''));
     await svc.fetch({ topic: 'alerts,backups' });
-    expect(calls[0]?.url).toContain('/alerts%2Cbackups/json');
+    expect(new URL(calls[0]?.url ?? '').pathname).toBe('/alerts,backups/json');
   });
 
   it('parses NDJSON line-by-line, skipping malformed and blank lines', async () => {


### PR DESCRIPTION
## Summary
- Preserve commas between topics when building the ntfy `/topic1,topic2/json` fetch URL.
- Continue percent-encoding each individual topic name so unsafe path characters are still escaped.
- Update the service regression to match the bundled ntfy API docs for multi-topic subscriptions.

## Test Plan
- [x] `bun install --frozen-lockfile`
- [x] `bun test tests/services/ntfy/ntfy-service.test.ts -t "preserves comma-separated"`
- [x] `bun test tests/services/ntfy/ntfy-service.test.ts`
- [x] `bun test`
- [x] `bun run build`
- [x] `bun run lint:mcp`
- [x] `bunx biome check .`
- [x] `git diff --check`
