### PR TITLE
fix(resource): normalize ntfy message timestamps

### DIFF
--- a/src/mcp-server/resources/definitions/ntfy-topic.resource.ts
+++ b/src/mcp-server/resources/definitions/ntfy-topic.resource.ts
@@ -9,6 +9,7 @@
 import { resource, z } from '@cyanheads/mcp-ts-core';
 import { forbidden } from '@cyanheads/mcp-ts-core/errors';
 
+import { shapeNtfyMessage } from '@/mcp-server/shared/ntfy-message.js';
 import { getCode, getMessage, isAuthCode } from '@/services/ntfy/error-classifier.js';
 import { getNtfyService } from '@/services/ntfy/ntfy-service.js';
 import type { NtfyMessage } from '@/services/ntfy/types.js';
@@ -66,7 +67,7 @@ export const ntfyTopicResource = resource('ntfy://{topic}', {
       url: `${service.baseUrl}/${params.topic}`,
       baseUrl: service.baseUrl,
       since: SNAPSHOT_SINCE,
-      messages: slice,
+      messages: slice.map(shapeNtfyMessage),
       count: slice.length,
       truncated,
     };

--- a/src/mcp-server/shared/ntfy-message.ts
+++ b/src/mcp-server/shared/ntfy-message.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Shared ntfy message shaping for tools and resources.
+ * Converts upstream Unix-second timestamps to ISO strings and bounds large
+ * message bodies for MCP clients.
+ * @module mcp-server/shared/ntfy-message
+ */
+
+import type {
+  MessageEvent,
+  NtfyAction,
+  NtfyAttachment,
+  NtfyMessage,
+  Priority,
+} from '@/services/ntfy/types.js';
+
+export const MESSAGE_TRUNCATE_AT = 500;
+
+export interface ShapedNtfyMessage {
+  actions?: NtfyAction[] | undefined;
+  attachment?: NtfyAttachment | undefined;
+  click?: string | undefined;
+  event: MessageEvent;
+  expires?: string | undefined;
+  id: string;
+  message?: string | undefined;
+  messageTruncated?: number | undefined;
+  priority?: Priority | undefined;
+  sequence_id?: string | undefined;
+  tags?: string[] | undefined;
+  time: string;
+  title?: string | undefined;
+  topic: string;
+}
+
+function truncateMessage(body: string | undefined): {
+  message?: string;
+  messageTruncated?: number;
+} {
+  if (body === undefined) return {};
+  if (body.length <= MESSAGE_TRUNCATE_AT) return { message: body };
+  return {
+    message: body.slice(0, MESSAGE_TRUNCATE_AT),
+    messageTruncated: body.length - MESSAGE_TRUNCATE_AT,
+  };
+}
+
+export function shapeNtfyMessage(raw: NtfyMessage): ShapedNtfyMessage {
+  const truncation = truncateMessage(raw.message);
+  return {
+    id: raw.id,
+    time: new Date(raw.time * 1000).toISOString(),
+    event: raw.event as MessageEvent,
+    topic: raw.topic,
+    expires: raw.expires !== undefined ? new Date(raw.expires * 1000).toISOString() : undefined,
+    sequence_id: raw.sequence_id,
+    title: raw.title,
+    message: truncation.message,
+    messageTruncated: truncation.messageTruncated,
+    priority: raw.priority,
+    tags: raw.tags,
+    click: raw.click,
+    actions: raw.actions,
+    attachment: raw.attachment,
+  };
+}

--- a/src/mcp-server/tools/definitions/ntfy-fetch-messages.tool.ts
+++ b/src/mcp-server/tools/definitions/ntfy-fetch-messages.tool.ts
@@ -13,6 +13,7 @@ import { tool, z } from '@cyanheads/mcp-ts-core';
 import { JsonRpcErrorCode, validationError } from '@cyanheads/mcp-ts-core/errors';
 
 import { getServerConfig } from '@/config/server-config.js';
+import { MESSAGE_TRUNCATE_AT, shapeNtfyMessage } from '@/mcp-server/shared/ntfy-message.js';
 import {
   getCode,
   getMessage,
@@ -24,7 +25,6 @@ import { getNtfyService } from '@/services/ntfy/ntfy-service.js';
 import type { NtfyMessage, Priority } from '@/services/ntfy/types.js';
 
 const TOPIC_LIST_REGEX = /^[a-zA-Z0-9_-]+(?:,[a-zA-Z0-9_-]+)*$/;
-const MESSAGE_TRUNCATE_AT = 500;
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
 
@@ -224,7 +224,6 @@ const OutputSchema = z.object({
 
 type Input = z.infer<typeof InputSchema>;
 type Output = z.infer<typeof OutputSchema>;
-type OutputMessage = Output['messages'][number];
 type FilterEcho = z.infer<typeof FilterEchoSchema>;
 
 function priorityLabel(p?: Priority): string {
@@ -240,38 +239,6 @@ function priorityLabel(p?: Priority): string {
     default:
       return 'default';
   }
-}
-
-function truncateMessage(body: string | undefined): {
-  message?: string;
-  messageTruncated?: number;
-} {
-  if (body === undefined) return {};
-  if (body.length <= MESSAGE_TRUNCATE_AT) return { message: body };
-  return {
-    message: body.slice(0, MESSAGE_TRUNCATE_AT),
-    messageTruncated: body.length - MESSAGE_TRUNCATE_AT,
-  };
-}
-
-function shapeMessage(raw: NtfyMessage): OutputMessage {
-  const truncation = truncateMessage(raw.message);
-  return {
-    id: raw.id,
-    time: new Date(raw.time * 1000).toISOString(),
-    event: raw.event as OutputMessage['event'],
-    topic: raw.topic,
-    expires: raw.expires !== undefined ? new Date(raw.expires * 1000).toISOString() : undefined,
-    sequence_id: raw.sequence_id,
-    title: raw.title,
-    message: truncation.message,
-    messageTruncated: truncation.messageTruncated,
-    priority: raw.priority,
-    tags: raw.tags,
-    click: raw.click,
-    actions: raw.actions as OutputMessage['actions'],
-    attachment: raw.attachment,
-  };
 }
 
 function filterSummary(f: FilterEcho | undefined): string {
@@ -435,7 +402,7 @@ export const ntfyFetchMessages = tool('ntfy_fetch_messages', {
       );
     }
 
-    return { messages: slice.map(shapeMessage) };
+    return { messages: slice.map(shapeNtfyMessage) };
   },
 
   format(result) {

--- a/tests/resources/ntfy-topic.resource.test.ts
+++ b/tests/resources/ntfy-topic.resource.test.ts
@@ -51,18 +51,29 @@ describe('ntfyTopicResource handler', () => {
     const svc = freshService();
     vi.spyOn(svc, 'fetch').mockResolvedValue([
       { id: 'a', time: 1, event: 'open', topic: 'alerts' },
-      { id: 'b', time: 2, event: 'message', topic: 'alerts', message: 'hi' },
+      {
+        id: 'b',
+        time: 2,
+        expires: 3602,
+        event: 'message',
+        topic: 'alerts',
+        message: 'hi',
+      },
     ]);
     const ctx = createMockContext({ uri: new URL('ntfy://alerts') });
     const result = (await ntfyTopicResource.handler({ topic: 'alerts' }, ctx)) as {
       topic: string;
       url: string;
-      messages: unknown[];
+      messages: Array<{ time: string; expires?: string }>;
       count: number;
     };
     expect(result.topic).toBe('alerts');
     expect(result.url).toBe('https://ntfy.test/alerts');
     expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({
+      time: '1970-01-01T00:00:02.000Z',
+      expires: '1970-01-01T01:00:02.000Z',
+    });
     expect(result.count).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- Normalize `ntfy://{topic}` resource messages with the same shaping used by `ntfy_fetch_messages`.
- Convert `time` and `expires` from ntfy Unix seconds to ISO 8601 strings in resource output.
- Extract the message shaper/truncation constant to a shared helper so the tool and resource stay consistent.

## Test Plan
- [x] `bun test tests/resources/ntfy-topic.resource.test.ts` (failed before the fix with numeric `time`/`expires`, passed after)
- [x] `bun test tests/resources/ntfy-topic.resource.test.ts tests/tools/ntfy-fetch-messages.tool.test.ts`
- [x] `bunx biome check src/mcp-server/shared/ntfy-message.ts src/mcp-server/resources/definitions/ntfy-topic.resource.ts src/mcp-server/tools/definitions/ntfy-fetch-messages.tool.ts tests/resources/ntfy-topic.resource.test.ts`
- [x] `bun run build`

Fixes #8
